### PR TITLE
Update infos regarding realtimeconfigquickscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
   * DISTRHO  
   * DPF-plugins  
   * Dragonfly
+  * Bertom Denoiser (https://www.bertomaudio.com/denoiser.html)
 
 11) Wine-tkg + yabridge
 

--- a/README.md
+++ b/README.md
@@ -111,18 +111,22 @@ Following this guide will hopefully allow you to get the best possible performan
 
 11) Wine-staging or Wine-tkg
 
-    Install wine-staging:
+    Install wine-staging v6.14:
     
     ```shell
-    yay -S wine-staging
+    yay -S downgrade
+    sudo DOWNGRADE_FROM_ALA=1 downgrade wine-staging
     ```
+    note that v6.14 is the last known working version of wine-staging that doesn't break yabridge so choose 6.14 from the resulting list and accept addition to IgnorePkg to avoid accidental upgrading.
     
     OR...for the more adventurous:
     
-    either download wine-tkg from https://github.com/Frogging-Family/wine-tkg-git/releases (Try v6.4 if you have any issues with latest)
+    either download wine-tkg from https://github.com/Frogging-Family/wine-tkg-git/releases
     
     or follow the instructions to git clone and install latest version:
     https://github.com/Frogging-Family/wine-tkg-git/tree/master/wine-tkg-git#quick-how-to-
+    
+    Be aware that recent versions break yabridge so try v6.4 if you are having issues.
         
 12) Install yabridge
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
     ```
     
     Also be sure to check out Bitwig Studio, Tracktion Waveform, Qtractor, LMMS, Rosegarden, Zrythm, Mixbus etc...
+    https://en.wikipedia.org/wiki/List_of_Linux_audio_software#Digital_audio_workstations_(DAWs)
 
 * Native plugins  
   * x42-plugins  
@@ -142,7 +143,7 @@
     
     
    ### Thanks
-   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expansion of steps 3, 4 & 5. Damien Zammit (of zam-plugins fame) for suggestion to add Ardour and MikeLupe from Ardour IRC channel for discussion of other Linux DAWs.
+   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expansion of steps 3, 4 & 5. Damien Zammit (of zam-plugins fame) for suggestion to add Ardour and MikeLupe from Ardour IRC channel for discussion of, and link to, other Linux DAWs.
 
 
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@
     
     
    ### Thanks
-   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expansion of steps 3, 4 & 5.
+   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expansion of steps 3, 4 & 5. Damien Zammit (of zam-plugins fame) for suggestion to add Ardour and MikeLupe from Ardour IRC channel for discussion of other Linux DAWs.
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     ```shell
     sudo usermod -a -G realtime,audio $USER
     ```
+    Log out/in or reboot...
 
 4) add "threadirqs" as kernel parameter
     ```shell

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Following this guide will hopefully allow you to get the best possible performan
     ```shell
     git clone https://github.com/raboof/realtimeconfigquickscan.git
     cd realtimeconfigquickscan
-    ./realtimeconfigquickscan
+    ./realtimeconfigquickscan.pl
     ```
 
 3) install realtime-privileges

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Following this guide will hopefully allow you to get the best possible performan
     ```shell
     git clone https://github.com/jhernberg/udev-rtirq.git
     cd udev-rtirq
-    make install
+    sudo make install
     reboot
     ```
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
     Also be sure to check out Bitwig Studio, Tracktion Waveform, Ardour, Mixbus, Qtractor, LMMS, Rosegarden, Zrythm etc...
     https://en.wikipedia.org/wiki/List_of_Linux_audio_software#Digital_audio_workstations_(DAWs)
 
-* Native plugins (yay -S [pkgname])
+* Native plugins (`yay -S [pkgname]`)
   * x42-plugins (https://x42-plugins.com/x42/)
   * airwindows-git (http://www.airwindows.com/)  
   * lsp-plugins  (https://lsp-plug.in/)

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ Following this guide will hopefully allow you to get the best possible performan
 
 11) Wine-staging or Wine-tkg
 
-    Install wine-staging v6.14:
+    Install wine-staging:
     
     ```shell
     yay -S downgrade
     sudo DOWNGRADE_FROM_ALA=1 downgrade wine-staging
     ```
-    note that v6.14 is the last known working version of wine-staging that doesn't break yabridge so choose 6.14 from the resulting list and accept addition to IgnorePkg to avoid accidental upgrading.
+    note that as of writing this, v6.14 is the last known working version of wine-staging that doesn't break yabridge so choose 6.14 from the resulting list and accept addition to IgnorePkg to avoid accidental upgrading. Check https://github.com/robbert-vdh/yabridge#tested-with for up-to-date info.
     
     OR...for the more adventurous:
     

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# ManjaroProAudio

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Following this guide will hopefully allow you to get the best possible performan
     nano ~/.bash_profile
     . ~/.bash_profile
     ```
+    
+    Or, if your shell is not bash, use the guide here: https://github.com/robbert-vdh/yabridge#environment-configuration
+    
     v. Install Windows VST2 and VST3 (preferred) plugins
     
     

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Following this guide will hopefully allow you to get the best possible performan
     iii. Configure yabridge according to https://github.com/robbert-vdh/yabridge#readme  
     iv. if using wine-tkg, append "export WINEFSYNC=1" to ~/.bash_profile  
     ```shell
-    nano ¬/.bash_profile
+    nano ~/.bash_profile
     . ~/.bash_profile
     ```
     v. Install Windows VST2 and VST3 (preferred) plugins

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pro Audio in Manjaro
 
+Following this guide will hopefully allow you to get the best possible performance on Linux for professional audio needs. Even though these steps are well-tested, it is wise to research what each step accomplishes and why (the search engine is your friend :P ).
+
 1) Install Manjaro KDE
 
 2) realtimeconfigquickscan

--- a/README.md
+++ b/README.md
@@ -96,15 +96,16 @@
     Also be sure to check out Bitwig Studio, Tracktion Waveform, Ardour, Mixbus, Qtractor, LMMS, Rosegarden, Zrythm etc...
     https://en.wikipedia.org/wiki/List_of_Linux_audio_software#Digital_audio_workstations_(DAWs)
 
-* Native plugins  
-  * x42-plugins  
-  * airwindows  
-  * LSP-plugins  
-  * zam-plugins  
-  * DISTRHO  
-  * DPF-plugins  
-  * Dragonfly
+* Native plugins (yay -S [pkgname])
+  * x42-plugins (https://x42-plugins.com/x42/)
+  * airwindows-git (http://www.airwindows.com/)  
+  * lsp-plugins  (https://lsp-plug.in/)
+  * zam-plugins  (http://www.zamaudio.com/?p=976)
+  * distrho-ports (https://distrho.sourceforge.io/ports.php)
+  * dpf-plugins (https://distrho.sourceforge.io/plugins.php)
+  * dragonfly-reverb (https://michaelwillis.github.io/dragonfly-reverb/)
   * Bertom Denoiser (https://www.bertomaudio.com/denoiser.html)
+  * sfizz / sfizz-git (https://sfz.tools/sfizz/)
 
 11) Wine-tkg + yabridge
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,22 @@
 
 11) Wine-tkg + yabridge
 
-    i. Install wine-tkg from https://github.com/Frogging-Family/wine-tkg-git/releases/tag/6.4.r0.g7ec998e1  
+    i. Download wine-tkg from https://github.com/Frogging-Family/wine-tkg-git/releases/download/6.4.r0.g7ec998e1/wine-tkg-staging-fsync-git-6.4.r0.g7ec998e1-322-x86_64.pkg.tar.zst  
+    
+    In download location run:
+    
+    ```shell
+    yay -U wine-tkg-staging-fsync-git-6.4.r0.g7ec998e1-322-x86_64.pkg.tar.zst
+    ```
+    
+    or, for the more adventurous:
+        
+    ```shell
+    git clone https://github.com/Frogging-Family/wine-tkg-git.git
+    cd wine-tkg-git/wine-tkg-git/
+    makepkg -si
+    ```
+        
     ii. Install yabridge
     ```shell
     yay -S yabridge-bin

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@
     
     
    ### Thanks
-   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expanding steps 3, 4 & 5.
+   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expansion of steps 3, 4 & 5.
 
 
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@
     
     
    ### Thanks
-   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expansion of steps 3, 4 & 5. Damien Zammit (of zam-plugins fame) for suggestion to add Ardour and MikeLupe from Ardour IRC channel for discussion of, and link to, other Linux DAWs.
+   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expansion of steps 3, 4 & 5. Damien Zammit (of zam-plugins fame) and MikeLupe for discussion of other Linux DAWs including Ardour and Zrythm.
 
 
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
     yay -S ardour
     ```
     
-    Also be sure to check out Bitwig Studio, Tracktion Waveform, Qtractor, Zrythm etc...
+    Also be sure to check out Bitwig Studio, Tracktion Waveform, Qtractor, LMMS, Rosegarden, Zrythm, Mixbus etc...
 
 * Native plugins  
   * x42-plugins  

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@
     ```shell
     yay -S yabridge-bin
     ```
+    or for latest git:
+    ```shell
+    yay -S yabridge-git yabridgectl-git
+    ```
+    
     iii. Configure yabridge according to https://github.com/robbert-vdh/yabridge#readme  
     iv. append "export WINEFSYNC=1" to ~/.bash_profile  
     ```shell

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
-# ManjaroProAudio
+# Pro Audio in Manjaro
+
+1) Install Manjaro KDE
+
+2) realtimeconfigquickscan
+    ```shell
+    git clone https://github.com/raboof/realtimeconfigquickscan.git
+    cd realtimeconfigquickscan
+    ./realtimeconfigquickscan
+    ```
+
+3) install realtime-privileges
+    ```shell
+    yay -S realtime-privileges
+    ```
+    Add user to "realtime" group  
+    Add user to "audio" group (to satisfy realtimeconfigquickscan)
+
+4) add "threadirqs" as kernel parameter
+    ```shell
+    sudo nano /etc/default/grub
+    sudo update-grub
+    ```
+
+5) Set governor to "performance"
+
+    i. Temporary:
+    ```shell
+    sudo cpupower frequency-set -g performance
+    ```
+    ii. Permanent:
+   
+    Add "cpufreq.default_governor=performance" as a kernel parameter
+    ```shell
+    sudo nano /etc/default/grub
+    sudo update-grub
+    ``````
+    or, for kernels < 5.9:
+    ```shell
+    sudo nano etc/default/cpupower` (uncomment governor and change to performance)
+    systemctl enable --now cpupower.service
+    systemctl start cpupower.service
+    ```
+
+
+6) swappiness
+    ```shell
+    sudo nano /etc/sysctl.d/99-sysctl.conf
+    ```
+    add "vm.swappiness=10"
+
+7) base-devel (as necessary)
+    ```shell
+    sudo pacman -S base-devel
+    ```
+
+8) install udev-rtirq
+    ```shell
+    git clone https://github.com/jhernberg/udev-rtirq.git
+    cd udev-rtirq
+    make install
+    reboot
+    ```
+
+9) Jack2 + Jack D-Bus
+    ```shell
+    yay -S qjackctl jack2-dbus
+    ```
+    Enable Jack D-Bus interface:  
+    ![image](https://user-images.githubusercontent.com/79659262/124497122-51218300-ddb2-11eb-8cb8-4bf873e026cd.png)
+
+
+10) DAWs & Plugins
+
+    REAPER: 
+    http://reaper.fm/download.php or,  
+    ```shell
+    yay -S reaper-bin
+    ```
+    change RT priority to 40 on audio device page?   
+    
+    Ardour:
+    ```shell
+    yay -S ardour
+    ```
+
+* Native plugins  
+  * x42-plugins  
+  * airwindows  
+  * LSP-plugins  
+  * zam-plugins  
+  * DISTRHO  
+  * DPF-plugins  
+  * Dragonfly
+
+11) Wine-tkg + yabridge
+
+    i. Install wine-tkg from https://github.com/Frogging-Family/wine-tkg-git/releases/tag/6.4.r0.g7ec998e1  
+    ii. Install yabridge
+    ```shell
+    yay -S yabridge-bin
+    ```
+    iii. Configure yabridge according to https://github.com/robbert-vdh/yabridge#readme  
+    iv. append "export WINEFSYNC=1" to ~/.bash_profile  
+    ```shell
+    nano ¬/.bash_profile
+    . ~/.bash_profile
+    ```
+    v. Install Windows VST2 and VST3 (preferred) plugins
+    
+    
+   ### Thanks
+   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods.
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Following this guide will hopefully allow you to get the best possible performan
     or follow the instructions to git clone and install latest version:
     https://github.com/Frogging-Family/wine-tkg-git/tree/master/wine-tkg-git#quick-how-to-
         
-    ii. Install yabridge
+12) Install yabridge
+
     ```shell
     yay -S yabridge-bin
     ```

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@
     yay -S reaper-bin
     ```
     change RT priority to 40 on audio device page?  
+    
+    Ardour:
+    https://community.ardour.org/download or,
+    ```shell
+    yay -S ardour
+    ```
 
 * Native plugins  
   * x42-plugins  

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Following this guide will hopefully allow you to get the best possible performan
     ```
     
     iii. Configure yabridge according to https://github.com/robbert-vdh/yabridge#readme  
-    iv. append "export WINEFSYNC=1" to ~/.bash_profile  
+    iv. if using wine-tkg, append "export WINEFSYNC=1" to ~/.bash_profile  
     ```shell
     nano ¬/.bash_profile
     . ~/.bash_profile

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@
     
     
    ### Thanks
-   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods.
+   Robbert van der Helm (of yabridge fame) for pointing out typos/omissions and suggesting alternative methods. JamesPeters (REAPER forums) for suggesting expanding steps 3, 4 & 5.
 
 
 

--- a/README.md
+++ b/README.md
@@ -92,13 +92,8 @@
     ```
     change RT priority to 40 on audio device page?  
     
-    Ardour:
-    https://community.ardour.org/download or,
-    ```shell
-    yay -S ardour
-    ```
     
-    Also be sure to check out Bitwig Studio, Tracktion Waveform, Qtractor, LMMS, Rosegarden, Zrythm, Mixbus etc...
+    Also be sure to check out Bitwig Studio, Tracktion Waveform, Ardour, Mixbus, Qtractor, LMMS, Rosegarden, Zrythm etc...
     https://en.wikipedia.org/wiki/List_of_Linux_audio_software#Digital_audio_workstations_(DAWs)
 
 * Native plugins  

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
     ```shell
     yay -S realtime-privileges
     ```
-    Add user to "realtime" group  
-    Add user to "audio" group (to satisfy realtimeconfigquickscan)
+    Add user to "realtime" group and "audio" group (to satisfy realtimeconfigquickscan)
+    ```shell
+    sudo usermod -a -G realtime,audio $USER
+    ```
 
 4) add "threadirqs" as kernel parameter
     ```shell

--- a/README.md
+++ b/README.md
@@ -70,19 +70,14 @@
     ![image](https://user-images.githubusercontent.com/79659262/124497122-51218300-ddb2-11eb-8cb8-4bf873e026cd.png)
 
 
-10) DAWs & Plugins
+10) DAW & Plugins
 
     REAPER: 
     http://reaper.fm/download.php or,  
     ```shell
     yay -S reaper-bin
     ```
-    change RT priority to 40 on audio device page?   
-    
-    Ardour:
-    ```shell
-    yay -S ardour
-    ```
+    change RT priority to 40 on audio device page?  
 
 * Native plugins  
   * x42-plugins  

--- a/README.md
+++ b/README.md
@@ -107,23 +107,20 @@
   * Bertom Denoiser (https://www.bertomaudio.com/denoiser.html)
   * sfizz / sfizz-git (https://sfz.tools/sfizz/)
 
-11) Wine-tkg + yabridge
+11) Wine-staging or Wine-tkg
 
-    i. Download wine-tkg from https://github.com/Frogging-Family/wine-tkg-git/releases/download/6.4.r0.g7ec998e1/wine-tkg-staging-fsync-git-6.4.r0.g7ec998e1-322-x86_64.pkg.tar.zst  
-    
-    In download location run:
+    Install wine-staging:
     
     ```shell
-    yay -U wine-tkg-staging-fsync-git-6.4.r0.g7ec998e1-322-x86_64.pkg.tar.zst
+    yay -S wine-staging
     ```
     
-    or, for the more adventurous:
-        
-    ```shell
-    git clone https://github.com/Frogging-Family/wine-tkg-git.git
-    cd wine-tkg-git/wine-tkg-git/
-    makepkg -si
-    ```
+    OR...for the more adventurous:
+    
+    either download wine-tkg from https://github.com/Frogging-Family/wine-tkg-git/releases (Try v6.4 if you have any issues with latest)
+    
+    or follow the instructions to git clone and install latest version:
+    https://github.com/Frogging-Family/wine-tkg-git/tree/master/wine-tkg-git#quick-how-to-
         
     ii. Install yabridge
     ```shell

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@
     ```shell
     yay -S ardour
     ```
+    
+    Also be sure to check out Bitwig Studio, Tracktion Waveform, Qtractor, Zrythm etc...
 
 * Native plugins  
   * x42-plugins  

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@
 4) add "threadirqs" as kernel parameter
     ```shell
     sudo nano /etc/default/grub
+    ```
+    change 
+    `GRUB_CMDLINE_LINUX=""` to `GRUB_CMDLINE_LINUX="threadirqs"`
+    
+    ```shell
     sudo update-grub
     ```
 
@@ -29,12 +34,17 @@
     sudo cpupower frequency-set -g performance
     ```
     ii. Permanent:
+    
+    Add `cpufreq.default_governor=performance` as a kernel parameter:
    
-    Add "cpufreq.default_governor=performance" as a kernel parameter
     ```shell
     sudo nano /etc/default/grub
+    ```
+    LIne should now read: 
+     `GRUB_CMDLINE_LINUX="cpufreq.default_governor=performance threadirqs"`
+     ```shell
     sudo update-grub
-    ``````
+    ```
     or, for kernels < 5.9:
     ```shell
     sudo nano etc/default/cpupower` (uncomment governor and change to performance)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Following this guide will hopefully allow you to get the best possible performan
     yay -S downgrade
     sudo DOWNGRADE_FROM_ALA=1 downgrade wine-staging
     ```
-    note that as of writing this, v6.14 is the last known working version of wine-staging that doesn't break yabridge so choose 6.14 from the resulting list and accept addition to IgnorePkg to avoid accidental upgrading. Check https://github.com/robbert-vdh/yabridge#tested-with for up-to-date info.
+    ~~note that as of writing this, v6.14 is the last known working version of wine-staging that doesn't break yabridge so choose 6.14 from the resulting list and accept addition to IgnorePkg to avoid accidental upgrading~~. Check https://github.com/robbert-vdh/yabridge#tested-with for up-to-date info.
     
     OR...for the more adventurous:
     

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Following this guide will hopefully allow you to get the best possible performan
     ```
     or, for kernels < 5.9:
     ```shell
-    sudo nano etc/default/cpupower` (uncomment governor and change to performance)
+    sudo nano /etc/default/cpupower (uncomment governor and change to performance)
     systemctl enable --now cpupower.service
     systemctl start cpupower.service
     ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Following this guide will hopefully allow you to get the best possible performan
 
 1) Install Manjaro KDE
 
-2) realtimeconfigquickscan
+2) rtcqs (formerly known as realtimeconfigquickscan)
     ```shell
-    git clone https://github.com/raboof/realtimeconfigquickscan.git
-    cd realtimeconfigquickscan
-    ./realtimeconfigquickscan.pl
+    git clone https://codeberg.org/rtcqs/rtcqs.git
+    cd rtcqs
+    ./rtcqs.py
     ```
 
 3) install realtime-privileges

--- a/license.md
+++ b/license.md
@@ -1,0 +1,1 @@
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.


### PR DESCRIPTION
With this commit https://github.com/raboof/realtimeconfigquickscan/commit/a9af61ace6b1c77dd796b55d7bc7a970048ecf93 the original author moved the project to https://codeberg.org/rtcqs/rtcqs.git